### PR TITLE
Fix enum wire values

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -211,6 +211,57 @@ service Maps
 	requireContains(t, output, "public let counts: WebRPCEnumMap<Flavor, UInt32>")
 }
 
+func TestExplicitEnumWireValuesRuntime(t *testing.T) {
+	schema := `
+webrpc = v1
+
+name = EnumWire
+version = v1.0.0
+basepath = /rpc
+
+enum WalletType: string
+  - Ethereum = "ethereum"
+  - SmartWallet = "smart-wallet"
+
+struct EchoRequest
+  - walletType: WalletType
+
+service EnumWire
+  - Echo(EchoRequest) => (EchoRequest)
+`
+
+	output := generateSwift(t, schema)
+	requireContains(t, output, `return "ethereum"`)
+	requireContains(t, output, `case "smart-wallet":`)
+
+	project := writeSwiftPackage(t, "enum-wire-values", map[string]string{
+		"Sources/Generated/Client.swift": output,
+		"Tests/GeneratedTests/GeneratedTests.swift": `
+import Foundation
+import XCTest
+@testable import Generated
+
+final class GeneratedTests: XCTestCase {
+    func testExplicitEnumWireValuesRoundTrip() throws {
+        let body = try EnumWireAPI.Echo.encodeRequest(EchoRequest(walletType: .ethereum))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["walletType"] as? String, "ethereum")
+
+        let responseData = try XCTUnwrap(#"{"walletType":"smart-wallet"}"#.data(using: .utf8))
+        let response = try EnumWireAPI.Echo.decodeResponse(responseData)
+        XCTAssertEqual(response.walletType, .smartWallet)
+    }
+
+    func testUnknownEnumWireValuePreserved() {
+        XCTAssertEqual(WalletType(wireValue: "unexpected"), .unknown("unexpected"))
+    }
+}
+`,
+	})
+
+	runSwiftTest(t, project)
+}
+
 func TestServiceNameCollisionGeneration(t *testing.T) {
 	schema := `
 webrpc = v1

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -18,7 +18,11 @@ public enum {{$type.Name}}: Codable, Hashable, Sendable, WebRPCEnumKey {
         switch self {
         {{- range $_, $field := $type.Fields}}
         case .{{template "swiftLowerCamel" dict "Name" $field.Name}}:
+            {{- if eq $type.Type.Expr "string" }}
+            return "{{$field.Value}}"
+            {{- else }}
             return "{{$field.Name}}"
+            {{- end }}
         {{- end}}
         case .unknown(let value):
             return value
@@ -28,7 +32,11 @@ public enum {{$type.Name}}: Codable, Hashable, Sendable, WebRPCEnumKey {
     public init(wireValue: String) {
         switch wireValue {
         {{- range $_, $field := $type.Fields}}
+            {{- if eq $type.Type.Expr "string" }}
+        case "{{$field.Value}}":
+            {{- else }}
         case "{{$field.Name}}":
+            {{- end }}
             self = .{{template "swiftLowerCamel" dict "Name" $field.Name}}
         {{- end}}
         default:


### PR DESCRIPTION
## Summary
- use explicit RIDL enum values for Swift string enum wire values instead of enum identifiers
- add runtime regression coverage for explicit string enum round-tripping
- update the external schema integration expectation to assert real wire values

## Why
The Swift generator was encoding and decoding enum names like `Ethereum` and `Native` instead of the explicit schema wire values like `ethereum` and `native`. That produces incompatible request and response payloads for schemas that define custom string enum values.

## Validation
- `go test ./...`
