### PR TITLE
feat: reject streaming schemas instead of emitting broken unary code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,8 @@ jobs:
       - name: Build example client
         run: make -C _examples/ClientExample build
 
+      - name: Verify streaming is rejected
+        run: make -C _examples test-streaming
+
       - name: Run shared Swift integration suite
         run: ./Tests/test.sh

--- a/_examples/Makefile
+++ b/_examples/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all generate build diff
+.PHONY: all generate build diff test-streaming
 
-all: generate diff build
+all: generate diff build test-streaming
 
 generate:
 	cd ClientExample && make generate
@@ -10,3 +10,11 @@ build:
 
 diff:
 	git diff --color --ignore-all-space --ignore-blank-lines --exit-code .
+
+test-streaming:
+	@echo "verifying streaming schemas are rejected"
+	@if go -C ../tools tool webrpc-gen -schema=../_examples/streaming.ridl -target=.. -client -out=/dev/null >/dev/null 2>&1; then \
+		echo "FAIL: streaming schema was not rejected"; exit 1; \
+	else \
+		echo "OK: streaming rejected"; \
+	fi

--- a/_examples/streaming.ridl
+++ b/_examples/streaming.ridl
@@ -1,0 +1,8 @@
+webrpc = v1
+
+name = streaming
+version = v1.0.0
+basepath = /rpc
+
+service StreamService
+    - Subscribe(channel: string) => stream (message: string)

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -28,6 +28,16 @@
   {{- exit 1 -}}
 {{- end -}}
 
+{{- /* Streaming is not supported; fail loudly rather than emit broken unary code. */ -}}
+{{- range $_, $service := .Services -}}
+  {{- range $_, $method := $service.Methods -}}
+    {{- if or $method.StreamInput $method.StreamOutput -}}
+      {{- stderrPrintf "%s generator error: streaming methods are not supported (%s.%s)\n" $.WebrpcTarget $service.Name $method.Name -}}
+      {{- exit 1 -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- $typeMap := dict -}}
 {{- set $typeMap "null" "WebRPCNull" -}}
 {{- set $typeMap "any" "WebRPCJSONValue" -}}


### PR DESCRIPTION
gen-swift silently generated a **unary** method for streaming RPCs (`func subscribe(...) async throws -> Subscribe.Response`), dropping the stream semantics. The output compiles but can't talk to a webrpc peer that serves the method as a stream. This fails generation loudly instead, matching the other webrpc generators.

---

## Change

- `main.go.tmpl`: error + exit if any method has `StreamInput`/`StreamOutput`.
- `_examples/streaming.ridl` + a `test-streaming` Makefile target asserting rejection; wired into the CI `swift-integration` job.

## Test plan

```
$ go -C tools tool webrpc-gen -schema=_examples/streaming.ridl -target=. -client -out=/dev/null
... generator error: streaming methods are not supported (StreamService.Subscribe)   # exit 1

$ make -C _examples test-streaming
OK: streaming rejected
```

Non-streaming generation is unchanged — the guard only fires on stream methods, and the example client still type-checks (`swiftc -typecheck`, clean).
