### PR TITLE
test+docs: cover type aliases, document -schemaHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ integration suite and tracked example checks on `macos-latest`.
 | --- | --- | --- |
 | `-client` | generate client code | unset (`false`) |
 | `-webrpcHeader` | send the standard `Webrpc` header on client requests | `true` |
+| `-schemaHash=false` | omit the schema hash + version constants from generated output | `true` |

--- a/Tests/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/Tests/GeneratedTests/GeneratedTests.swift
@@ -3,6 +3,18 @@ import XCTest
 @testable import Generated
 
 final class GeneratedTests: XCTestCase {
+    func testTypeAliasResolvesToUnderlyingType() throws {
+        // `type UserID: uint64` in test.ridl must render a typealias to the base type.
+        let id: UserID = 42
+        XCTAssertEqual(id, UInt64(42))
+
+        // Aliases are usable wherever the base type is expected (e.g. request fields).
+        let request = HelperAPI.GetUser.Request(userId: id)
+        let body = try HelperAPI.GetUser.encodeRequest(request)
+        let bodyJSON = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        XCTAssertEqual(bodyJSON?["userId"] as? NSNumber, 42)
+    }
+
     func testHelperRoundTripWorks() throws {
         let request = HelperAPI.GetUser.Request(userId: 7)
         let body = try HelperAPI.GetUser.encodeRequest(request)

--- a/Tests/test.ridl
+++ b/Tests/test.ridl
@@ -4,6 +4,8 @@ name = Helper
 version = v1.0.0
 basepath = /rpc
 
+type UserID: uint64
+
 struct Ledger
   - amount: bigint
   - amounts: []bigint
@@ -20,7 +22,7 @@ struct Box
   - payload: any
 
 service Helper
-  - GetUser(userId: uint64) => (code: uint32, username: string)
+  - GetUser(userId: UserID) => (code: uint32, username: string)
   - EchoLedger(Ledger) => (Ledger)
   - EchoBasket(Basket) => (Basket)
   - EchoBox(Box) => (Box)


### PR DESCRIPTION
Two release-readiness fixes for gen-swift:

1. **Type-alias test coverage** — the template renders `type Name: Base` as a Swift `typealias`, but nothing exercised it (no alias in the test schema, no assertion). Added `type UserID: uint64` to `Tests/test.ridl` and a test asserting it resolves to the underlying type and is usable as a request field.
2. **Docs** — documented the `-schemaHash` opt-out in the README options table.

---

`Tests/Sources/Generated/Generated.swift` is gitignored and regenerated by `Tests/test.sh` in CI, so it isn't committed. I regenerated locally with the pinned tool (webrpc-gen v0.37.2) and confirmed the output:

```
public typealias UserID = UInt64
```

I could not run `swift test` locally (no Swift toolchain in my env) — CI's `Tests/test.sh` regenerates and compiles/exercises the alias. Flagging that explicitly rather than claiming the Swift suite passed.

Part of the cross-generator sweep documenting `-schemaHash` and closing type-alias coverage gaps.
